### PR TITLE
Update pages that buttons in About page lead to

### DIFF
--- a/src/pages/About/AboutKyberSwap.tsx
+++ b/src/pages/About/AboutKyberSwap.tsx
@@ -44,9 +44,6 @@ import { ExternalLink, StyledInternalLink } from 'theme'
 import { useDarkModeManager } from 'state/user/hooks'
 import githubImg from 'assets/svg/about_icon_github.png'
 import githubImgLight from 'assets/svg/about_icon_github_light.png'
-import { KNC } from 'constants/index'
-import { ChainId } from '@kyberswap/ks-sdk-core'
-import { useActiveWeb3React } from 'hooks'
 import { useGlobalData } from 'state/about/hooks'
 import { formatBigLiquidity } from 'utils/formatBalance'
 import {
@@ -81,29 +78,8 @@ import { dexListConfig } from 'constants/dexes'
 import { MAINNET_NETWORKS } from 'constants/networks'
 import useMixpanel, { MIXPANEL_TYPE } from 'hooks/useMixpanel'
 import Banner from 'components/Banner'
-// import { Swiper, SwiperSlide } from 'swiper/react/swiper-react'
-// import { Pagination, FreeMode } from 'swiper'
-import { nativeOnChain } from 'constants/tokens'
 import AntiSnippingAttack from 'components/Icons/AntiSnippingAttack'
 import { VERSION } from 'constants/v2'
-
-const KNC_NOT_AVAILABLE_IN = [
-  ChainId.CRONOS,
-  ChainId.AVAXMAINNET,
-  ChainId.FANTOM,
-  ChainId.BTTC,
-  ChainId.ARBITRUM,
-  ChainId.AURORA,
-  ChainId.VELAS,
-  ChainId.OASIS,
-  ChainId.OPTIMISM,
-]
-
-const getPoolsMenuLink = (chainId?: ChainId, path?: string) => {
-  const pathname = path || 'pools'
-  if (chainId && KNC_NOT_AVAILABLE_IN.includes(chainId)) return `/${pathname}/${nativeOnChain(chainId).symbol}`
-  return `/${pathname}/${nativeOnChain(chainId as ChainId).symbol || 'ETH'}/${KNC[chainId as ChainId].address}`
-}
 
 export const KSStatistic = () => {
   const theme = useTheme()
@@ -170,9 +146,6 @@ function AboutKyberSwap() {
   const above768 = useMedia('(min-width: 768px)')
   const above500 = useMedia('(min-width: 500px)')
 
-  const { chainId } = useActiveWeb3React()
-  const poolsMenuLink = getPoolsMenuLink(chainId)
-  const createPoolLink = getPoolsMenuLink(chainId, 'create')
   const data = useGlobalData()
 
   const globalData = data && data.dmmFactories[0]
@@ -483,7 +456,7 @@ function AboutKyberSwap() {
             </BtnPrimary>
             <BtnOutlined
               as={Link}
-              to={poolsMenuLink}
+              to={'/pools?tab=elastic'}
               onClick={() => mixpanelHandler(MIXPANEL_TYPE.ABOUT_START_EARNING_CLICKED)}
             >
               <MoneyBag color={theme.btnOutline} />
@@ -816,7 +789,7 @@ function AboutKyberSwap() {
           >
             <BtnPrimary
               as={Link}
-              to={poolsMenuLink}
+              to={activeTab === VERSION.ELASTIC ? '/pools?tab=elastic' : '/pools?tab=classic'}
               onClick={() => mixpanelHandler(MIXPANEL_TYPE.ABOUT_START_EARNING_CLICKED)}
             >
               <MoneyBag size={20} color={theme.textReverse} />
@@ -824,7 +797,11 @@ function AboutKyberSwap() {
                 <Trans>Start Earning</Trans>
               </Text>
             </BtnPrimary>
-            <BtnOutlined as={Link} to="/farms" onClick={() => mixpanelHandler(MIXPANEL_TYPE.ABOUT_VIEW_FARMS_CLICKED)}>
+            <BtnOutlined
+              as={Link}
+              to={activeTab === VERSION.ELASTIC ? '/farms?farmType=elastic' : '/farms?farmType=classic'}
+              onClick={() => mixpanelHandler(MIXPANEL_TYPE.ABOUT_VIEW_FARMS_CLICKED)}
+            >
               <FarmIcon size={20} color={theme.btnOutline} />
               <Text fontSize="16px" marginLeft="8px">
                 <Trans>View Farms</Trans>
@@ -893,7 +870,7 @@ function AboutKyberSwap() {
           >
             <BtnPrimary
               as={Link}
-              to={createPoolLink}
+              to={'/pools?tab=elastic'}
               onClick={() => mixpanelHandler(MIXPANEL_TYPE.ABOUT_CREATE_NEW_POOL_CLICKED)}
             >
               <Plus size={20} />

--- a/src/pages/About/AboutKyberSwap.tsx
+++ b/src/pages/About/AboutKyberSwap.tsx
@@ -870,7 +870,7 @@ function AboutKyberSwap() {
           >
             <BtnPrimary
               as={Link}
-              to={'/pools?tab=elastic'}
+              to={'/pools?tab=elastic&highlightCreateButton=true'}
               onClick={() => mixpanelHandler(MIXPANEL_TYPE.ABOUT_CREATE_NEW_POOL_CLICKED)}
             >
               <Plus size={20} />

--- a/src/pages/Pools/index.tsx
+++ b/src/pages/Pools/index.tsx
@@ -3,6 +3,7 @@ import { Link, RouteComponentProps } from 'react-router-dom'
 import { useMedia } from 'react-use'
 import { t, Trans } from '@lingui/macro'
 import { Flex, Text } from 'rebass'
+import styled, { keyframes, DefaultTheme } from 'styled-components'
 
 import { Currency, ChainId } from '@kyberswap/ks-sdk-core'
 import { ButtonLight, ButtonPrimary } from 'components/Button'
@@ -32,6 +33,26 @@ import { stringify } from 'qs'
 import { ELASTIC_NOT_SUPPORTED, VERSION } from 'constants/v2'
 import { MouseoverTooltip } from 'components/Tooltip'
 
+const highlight = (theme: DefaultTheme) => keyframes`
+  0%{
+    box-shadow: 0 0 0px 0px ${theme.primary};
+  }
+  100%{
+    box-shadow: 0 0 8px 4px ${theme.primary};
+  }
+`
+
+const ButtonCreatePool = styled(ButtonPrimary)`
+  padding: 10px 12px;
+  float: right;
+  border-radius: 40px;
+  font-size: 14px;
+
+  &[data-highlight='true'] {
+    animation: ${({ theme }) => highlight(theme)} 0.8s 8 alternate ease-in-out;
+  }
+`
+
 const Pools = ({
   match: {
     params: { currencyIdA, currencyIdB },
@@ -50,6 +71,7 @@ const Pools = ({
   const debouncedSearchValue = useDebounce(searchValueInQs.trim().toLowerCase(), 200)
 
   const tab = (qs.tab as string) || VERSION.ELASTIC
+  const shouldHighlightButtonCreatePool = qs.highlightCreateButton === 'true'
   const onSearch = (search: string) => {
     history.replace(location.pathname + '?search=' + search + '&tab=' + tab)
   }
@@ -171,11 +193,7 @@ const Pools = ({
 
         <FarmingPoolsMarquee tab={tab} />
 
-        {(tab === VERSION.ELASTIC ? (
-          above1260
-        ) : (
-          above1000
-        )) ? (
+        {(tab === VERSION.ELASTIC ? above1260 : above1000) ? (
           <ToolbarWrapper>
             <CurrencyWrapper>
               <PoolsCurrencyInputPanel
@@ -225,7 +243,7 @@ const Pools = ({
 
                 <FarmingPoolsToggle
                   isActive={isShowOnlyActiveFarmPools}
-                  toggle={() => setIsShowOnlyActiveFarmPools(prev => !prev)}
+                  toggle={() => setIsShowOnlyActiveFarmPools((prev) => !prev)}
                 />
               </Flex>
 
@@ -260,36 +278,32 @@ const Pools = ({
                 </ToolbarWrapper>
               )}
               <ToolbarWrapper style={{ marginBottom: '0px' }}>
-                <Text fontSize="20px" fontWeight={500}></Text>
-                <SearchWrapper>
-                  <ButtonPrimary
-                    padding="10px 12px"
-                    as={Link}
-                    onClick={() => {
-                      if (tab === VERSION.CLASSIC) {
-                        mixpanelHandler(MIXPANEL_TYPE.CREATE_POOL_INITITATED)
-                      } else {
-                        mixpanelHandler(MIXPANEL_TYPE.ELASTIC_CREATE_POOL_INITIATED)
-                      }
-                    }}
-                    to={
-                      tab === VERSION.CLASSIC
-                        ? `/create/${currencyIdA === '' ? undefined : currencyIdA}/${
-                            currencyIdB === '' ? undefined : currencyIdB
-                          }`
-                        : `/elastic/add${
-                            currencyIdA && currencyIdB
-                              ? `/${currencyIdA}/${currencyIdB}`
-                              : currencyIdA || currencyIdB
-                              ? `/${currencyIdA || currencyIdB}`
-                              : ''
-                          }`
+                <ButtonCreatePool
+                  as={Link}
+                  onClick={() => {
+                    if (tab === VERSION.CLASSIC) {
+                      mixpanelHandler(MIXPANEL_TYPE.CREATE_POOL_INITITATED)
+                    } else {
+                      mixpanelHandler(MIXPANEL_TYPE.ELASTIC_CREATE_POOL_INITIATED)
                     }
-                    style={{ float: 'right', borderRadius: '40px', fontSize: '14px' }}
-                  >
-                    <Trans>Create Pool</Trans>
-                  </ButtonPrimary>
-                </SearchWrapper>
+                  }}
+                  to={
+                    tab === VERSION.CLASSIC
+                      ? `/create/${currencyIdA === '' ? undefined : currencyIdA}/${
+                          currencyIdB === '' ? undefined : currencyIdB
+                        }`
+                      : `/elastic/add${
+                          currencyIdA && currencyIdB
+                            ? `/${currencyIdA}/${currencyIdB}`
+                            : currencyIdA || currencyIdB
+                            ? `/${currencyIdA || currencyIdB}`
+                            : ''
+                        }`
+                  }
+                  data-highlight={shouldHighlightButtonCreatePool}
+                >
+                  <Trans>Create Pool</Trans>
+                </ButtonCreatePool>
               </ToolbarWrapper>
             </Flex>
           </ToolbarWrapper>
@@ -423,7 +437,7 @@ const Pools = ({
 
                 <FilterBarToggle
                   isActive={isShowOnlyActiveFarmPools}
-                  toggle={() => setIsShowOnlyActiveFarmPools(prev => !prev)}
+                  toggle={() => setIsShowOnlyActiveFarmPools((prev) => !prev)}
                 />
               </Flex>
             </Flex>


### PR DESCRIPTION
# Description

1. ‘Start Earning’ button at the top should redirect to Pools page (Elastic tab)
2. ‘Start Earning’ button under ‘For Liquidity Providers’ for ‘KyberSwap Elastic’ should redirect to Pools page (Elastic tab)
3. ‘Start Earning’ button under ‘For Liquidity Providers’ for ‘KyberSwap Classic’ should redirect to Pools page (Classic tab)
4. ‘View Farms’ button under ‘For Liquidity Providers’ for ‘KyberSwap Elastic’ should redirect to Farms page (Elastic tab)
5. ‘View Farms’ button under ‘For Liquidity Providers’ for ‘KyberSwap Classic’ should redirect to Farms page (Classic tab)
6. ‘Create New Pool’ button should redirect to Pools page (Elastic tab) and highlight the Create Pool button