### PR TITLE
Hide liquidity sources that have same name

### DIFF
--- a/src/components/swapv2/LiquiditySourcesPanel/index.tsx
+++ b/src/components/swapv2/LiquiditySourcesPanel/index.tsx
@@ -7,12 +7,24 @@ import { t } from '@lingui/macro'
 import { useActiveWeb3React } from 'hooks'
 import useDebounce from 'hooks/useDebounce'
 import useAggregatorStats from 'hooks/useAggregatorStats'
-import { dexListConfig } from 'constants/dexes'
+import { DexConfig, dexListConfig } from 'constants/dexes'
 
 import SearchBar from './SearchBar'
 
 type Props = {
   onBack: () => void
+}
+
+export const extractUniqueDEXes = (dexIDs: string[]): DexConfig[] => {
+  const visibleDEXes = dexIDs.map(id => dexListConfig[id]).filter(Boolean)
+
+  // Names of different IDs can be the same
+  const dexConfigByName = visibleDEXes.reduce((acc, dex) => {
+    acc[dex.name] = dex
+    return acc
+  }, {} as Record<string, DexConfig>)
+
+  return Object.values(dexConfigByName)
 }
 
 const BackIconWrapper = styled(ArrowLeft)`
@@ -108,10 +120,7 @@ const LiquiditySourcesPanel: React.FC<Props> = ({ onBack }) => {
     return null
   }
 
-  const visibleDEXes = dexIDs
-    .map(id => dexListConfig[id])
-    .filter(Boolean)
-    .filter(({ name }) => name.toLowerCase().includes(debouncedSearchText))
+  const visibleDEXes = extractUniqueDEXes(dexIDs).filter(({ name }) => name.toLowerCase().includes(debouncedSearchText))
 
   return (
     <Box width="100%">

--- a/src/components/swapv2/SwapSettingsPanel/LiquiditySourcesSetting.tsx
+++ b/src/components/swapv2/SwapSettingsPanel/LiquiditySourcesSetting.tsx
@@ -10,6 +10,8 @@ import useAggregatorStats from 'hooks/useAggregatorStats'
 import { useActiveWeb3React } from 'hooks'
 import useTheme from 'hooks/useTheme'
 
+import { extractUniqueDEXes } from '../LiquiditySourcesPanel'
+
 type Props = {
   onClick: () => void
 }
@@ -43,10 +45,12 @@ const LiquiditySourcesSetting: React.FC<Props> = ({ onClick }) => {
     return null
   }
 
-  const numberOfDEXes = Object.keys(data.pools).length
-  if (numberOfDEXes === 0) {
+  const dexIDs = Object.keys(data.pools)
+  if (dexIDs.length === 0) {
     return null
   }
+
+  const numberOfDEXes = extractUniqueDEXes(dexIDs).length
 
   return (
     <Flex

--- a/src/components/swapv2/SwapSettingsPanel/index.tsx
+++ b/src/components/swapv2/SwapSettingsPanel/index.tsx
@@ -56,7 +56,6 @@ const BackText = styled.span`
 `
 
 const SettingsPanel: React.FC<Props> = ({ className, onBack, onClickLiquiditySources, onClickGasPriceTracker }) => {
-  
   const theme = useTheme()
 
   const { data: topTrendingSoonTokens } = useTopTrendingSoonTokensInCurrentNetwork()


### PR DESCRIPTION
# Description
Some sources have different IDs but a same name and we need to avoid these duplications