### PR TITLE
Handle missing favorite tokens from local storage

### DIFF
--- a/src/components/SearchModal/CurrencyList.tsx
+++ b/src/components/SearchModal/CurrencyList.tsx
@@ -30,6 +30,7 @@ import CurrencyLogo from '../CurrencyLogo'
 import { MouseoverTooltip } from '../Tooltip'
 import Loader from '../Loader'
 import ImportRow from './ImportRow'
+import { useUserFavoriteTokens } from 'state/user/hooks'
 
 function currencyKey(currency: Currency): string {
   return currency?.isNative ? 'ETHER' : currency?.address || ''
@@ -186,27 +187,24 @@ function CurrencyRow({
   const nativeCurrency = useCurrencyConvertedToNative(currency || undefined)
   // only show add or remove buttons if not on selected list
 
-  const isFavorite = useSelector((state: AppState) => {
-    if (!chainId) {
-      return false
-    }
+  const { favoriteTokens, toggleFavoriteToken } = useUserFavoriteTokens(chainId)
 
-    const data = state.user.favoriteTokensByChainId[chainId]
-    if (!data) {
+  const isFavorite = (() => {
+    if (!chainId || !favoriteTokens) {
       return false
     }
 
     if (currency.isNative) {
-      return data.includeNativeToken
+      return !!favoriteTokens.includeNativeToken
     }
 
     if (currency.isToken) {
       const addr = (currency as Token).address
-      return data.addresses.includes(addr)
+      return !!favoriteTokens.addresses?.includes(addr)
     }
 
     return false
-  })
+  })()
 
   const handleClickFavorite = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation()
@@ -216,22 +214,18 @@ function CurrencyRow({
     }
 
     if (currency.isNative) {
-      dispatch(
-        toggleFavoriteToken({
-          chainId,
-          isNative: true,
-        }),
-      )
+      toggleFavoriteToken({
+        chainId,
+        isNative: true,
+      })
       return
     }
 
     if (currency.isToken) {
-      dispatch(
-        toggleFavoriteToken({
-          chainId,
-          address: (currency as Token).address,
-        }),
-      )
+      toggleFavoriteToken({
+        chainId,
+        address: (currency as Token).address,
+      })
     }
   }
 

--- a/src/components/SearchModal/CurrencySearch.tsx
+++ b/src/components/SearchModal/CurrencySearch.tsx
@@ -5,10 +5,15 @@ import { FixedSizeList } from 'react-window'
 import { Flex, Text } from 'rebass'
 import AutoSizer from 'react-virtualized-auto-sizer'
 import { t, Trans } from '@lingui/macro'
-
 import { Currency, Token, ChainId } from '@kyberswap/ks-sdk-core'
-import ImportRow from './ImportRow'
-import { useActiveWeb3React } from '../../hooks'
+
+import useTheme from 'hooks/useTheme'
+import useToggle from 'hooks/useToggle'
+import { useOnClickOutside } from 'hooks/useOnClickOutside'
+import useDebounce from 'hooks/useDebounce'
+import { nativeOnChain } from 'constants/tokens'
+import InfoHelper from 'components/InfoHelper'
+import { useUserFavoriteTokens } from 'state/user/hooks'
 import {
   useAllTokens,
   useToken,
@@ -16,6 +21,9 @@ import {
   useIsTokenActive,
   useSearchInactiveTokenLists,
 } from 'hooks/Tokens'
+
+import ImportRow from './ImportRow'
+import { useActiveWeb3React } from '../../hooks'
 import { CloseIcon, TYPE, ButtonText, IconWrapper } from '../../theme'
 import { isAddress } from '../../utils'
 import Row, { RowBetween, RowFixed } from '../Row'
@@ -26,14 +34,6 @@ import { filterTokens } from './filtering'
 import SortButton from './SortButton'
 import { useTokenComparator } from './sorting'
 import { PaddedColumn, SearchInput, Separator } from './styleds'
-import useTheme from 'hooks/useTheme'
-import useToggle from 'hooks/useToggle'
-import { useOnClickOutside } from 'hooks/useOnClickOutside'
-import useDebounce from 'hooks/useDebounce'
-import { nativeOnChain } from 'constants/tokens'
-import InfoHelper from 'components/InfoHelper'
-import { useSelector } from 'react-redux'
-import { AppState } from 'state'
 
 enum Tab {
   All,
@@ -101,12 +101,7 @@ export function CurrencySearch({
   const [searchQuery, setSearchQuery] = useState<string>('')
   const debouncedQuery = useDebounce(searchQuery, 200)
 
-  const favoriteTokens = useSelector((state: AppState) => {
-    if (!chainId) {
-      return undefined
-    }
-    return state.user.favoriteTokensByChainId[chainId]
-  })
+  const { favoriteTokens } = useUserFavoriteTokens(chainId)
 
   const [invertSearchOrder, setInvertSearchOrder] = useState<boolean>(false)
   const allTokens = useAllTokens()

--- a/src/state/user/actions.ts
+++ b/src/state/user/actions.ts
@@ -42,7 +42,7 @@ export const toggleTokenInfo = createAction<void>('user/toggleTokenInfo')
 export const toggleTopTrendingTokens = createAction<void>('user/toggleTopTrendingTokens')
 export const toggleProLiveChart = createAction<void>('user/toggleProLiveChart')
 
-type ToggleFavoriteTokenPayload = {
+export type ToggleFavoriteTokenPayload = {
   chainId: ChainId
 } & ({ isNative?: false; address: string } | { isNative: true; address?: never })
 export const toggleFavoriteToken = createAction<ToggleFavoriteTokenPayload>('user/toggleFavoriteToken')

--- a/src/state/user/hooks.tsx
+++ b/src/state/user/hooks.tsx
@@ -9,7 +9,7 @@ import { SupportedLocale } from 'constants/locales'
 
 import { useActiveWeb3React } from '../../hooks'
 import { AppDispatch, AppState } from 'state'
-import { useAppDispatch } from 'state/hooks'
+import { useAppDispatch, useAppSelector } from 'state/hooks'
 import {
   addSerializedPair,
   addSerializedToken,
@@ -28,11 +28,12 @@ import {
   toggleProLiveChart,
   toggleTopTrendingTokens,
   toggleTokenInfo,
+  toggleFavoriteToken as toggleFavoriteTokenAction,
+  ToggleFavoriteTokenPayload,
 } from './actions'
 import { useUserLiquidityPositions } from 'state/pools/hooks'
 import { useAllTokens } from 'hooks/Tokens'
 import { isAddress } from 'utils'
-import { useAppSelector } from 'state/hooks'
 import { WrappedTokenInfo } from 'state/lists/wrappedTokenInfo'
 import { defaultShowLiveCharts } from './reducer'
 import {
@@ -494,4 +495,26 @@ export function useToggleTokenInfo(): () => void {
 export function useToggleTopTrendingTokens(): () => void {
   const dispatch = useDispatch<AppDispatch>()
   return useCallback(() => dispatch(toggleTopTrendingTokens()), [dispatch])
+}
+
+export const useUserFavoriteTokens = (chainId: ChainId | undefined) => {
+  const dispatch = useDispatch<AppDispatch>()
+  const favoriteTokens = useSelector((state: AppState) => {
+    if (!chainId) {
+      return undefined
+    }
+
+    if (!state.user.favoriteTokensByChainId) {
+      return undefined
+    }
+
+    return state.user.favoriteTokensByChainId[chainId]
+  })
+
+  const toggleFavoriteToken = useCallback(
+    (payload: ToggleFavoriteTokenPayload) => dispatch(toggleFavoriteTokenAction(payload)),
+    [dispatch],
+  )
+
+  return { favoriteTokens, toggleFavoriteToken }
 }

--- a/src/state/user/reducer.ts
+++ b/src/state/user/reducer.ts
@@ -224,6 +224,10 @@ export default createReducer(initialState, builder =>
       state.showTopTrendingSoonTokens = !state.showTopTrendingSoonTokens
     })
     .addCase(toggleFavoriteToken, (state, { payload: { chainId, isNative, address } }) => {
+      if (!state.favoriteTokensByChainId) {
+        state.favoriteTokensByChainId = {}
+      }
+
       let favoriteTokens = state.favoriteTokensByChainId[chainId]
       if (!favoriteTokens) {
         favoriteTokens = {


### PR DESCRIPTION
# Description
- @nguyenhoaidanh has detected a bug in existing users who haven't selected any favorite tokens before, which means the localStorage didn't have a field named `favoriteTokensByChainId`.
- This PR adds a check in case the field is undefined