### PR TITLE
Fix minor UI issues

### DIFF
--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -6,7 +6,7 @@ import useTheme from 'hooks/useTheme'
 import { X } from 'react-feather'
 import { ButtonEmpty } from 'components/Button'
 
-const Container = styled.div`
+export const Container = styled.div`
   z-index: 1;
   position: relative;
   background-color: ${({ theme }) => theme.background};
@@ -17,7 +17,7 @@ const Container = styled.div`
   }
 `
 
-const Wrapper = styled.div<{ minWidth?: string }>`
+export const Wrapper = styled.div<{ minWidth?: string }>`
   display: flex;
   position: relative;
   flex-direction: row;
@@ -33,7 +33,7 @@ const Wrapper = styled.div<{ minWidth?: string }>`
     min-width: 100%;
   }
 `
-const Input = styled.input`
+export const Input = styled.input`
   position: relative;
   display: flex;
   align-items: center;

--- a/src/components/YieldPools/FarmGuide.tsx
+++ b/src/components/YieldPools/FarmGuide.tsx
@@ -1,18 +1,20 @@
 import React, { useState } from 'react'
+import { Flex, Text } from 'rebass'
+import { ChevronDown, Eye } from 'react-feather'
+import { useMedia } from 'react-use'
+import { isMobile } from 'react-device-detect'
+
 import { VERSION } from 'constants/v2'
 import { ProMMFarmGuideWrapper, ProMMFarmGuide, ShowGuideBtn, ChevronRight, GuideWrapper, GuideItem } from './styleds'
-import { Flex, Text } from 'rebass'
 import { ExternalLink, StyledInternalLink } from 'theme'
 import { Trans } from '@lingui/macro'
-import { ChevronDown, Eye } from 'react-feather'
 import useTheme from 'hooks/useTheme'
 import { Drop, MoneyBag } from 'components/Icons'
 import Deposit from 'components/Icons/Deposit'
 import AgriCulture from 'components/Icons/AgriCulture'
-import { useMedia } from 'react-use'
 
 function FarmGuide({ farmType }: { farmType: VERSION }) {
-  const [show, setShow] = useState(true)
+  const [show, setShow] = useState(!isMobile)
   const theme = useTheme()
   const upToMedium = useMedia('(max-width: 992px)')
 

--- a/src/pages/About/AboutKyberSwap.tsx
+++ b/src/pages/About/AboutKyberSwap.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { Text, Flex } from 'rebass'
+import { Text, Flex, Box } from 'rebass'
 import { Link } from 'react-router-dom'
 import useTheme from 'hooks/useTheme'
 import { Trans } from '@lingui/macro'
@@ -88,61 +88,82 @@ const KNCBlack = styled(KNCSVG)`
   }
 `
 
+const ForTraderInfoRow = styled.div`
+  flex: 1 1 100%;
+  display: flex;
+  ${({ theme }) => theme.mediaWidth.upToLarge`
+    flex: 1;  
+    gap: 24px;
+    width: 100%;
+    height: 100%;
+  `}
+`
+
+const ForTraderInfoCell = styled.div`
+  flex: 1 1 100%;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  ${({ theme }) => theme.mediaWidth.upToLarge`
+    flex: 1;  
+  `}
+`
+
 export const KSStatistic = () => {
   const theme = useTheme()
-  const above992 = useMedia('(min-width: 992px)')
+  const upToLarge = useMedia('(max-width: 1200px)')
 
   return (
-    <>
-      <div style={{ position: 'relative', marginTop: '20px' }}>
-        <ForTraderInfoShadow />
-        <ForTraderInfo>
-          <Flex sx={{ gap: '24px' }} height={above992 ? '100%' : 'unset'} width={above992 ? 'unset' : '100%'}>
-            <Flex flexDirection="column" alignItems="center" flex={!above992 ? 1 : 'unset'}>
-              <Text fontWeight="600" fontSize="24px">
-                $24B
-              </Text>
-              <Text color={theme.subText} marginTop="4px" fontSize="14px">
-                <Trans>TVL From DEXs</Trans>
-              </Text>
-            </Flex>
+    <Box sx={{ position: 'relative', marginTop: '20px' }}>
+      <ForTraderInfoShadow />
+      <ForTraderInfo>
+        <ForTraderInfoRow>
+          <ForTraderInfoCell>
+            <Text fontWeight="600" fontSize="24px">
+              $24B
+            </Text>
+            <Text color={theme.subText} marginTop="4px" fontSize="14px">
+              <Trans>TVL From DEXs</Trans>
+            </Text>
+          </ForTraderInfoCell>
 
-            <ForTraderDivider />
+          <ForTraderDivider />
 
-            <Flex flexDirection="column" alignItems="center" flex={!above992 ? 1 : 'unset'}>
-              <Text fontWeight="600" fontSize="24px">
-                {Object.keys(dexListConfig).length - 1}+{/* DMM and KyberSwap are one */}
-              </Text>
-              <Text color={theme.subText} marginTop="4px" fontSize="14px">
-                <Trans>DEXs</Trans>
-              </Text>
-            </Flex>
-          </Flex>
+          <ForTraderInfoCell>
+            <Text fontWeight="600" fontSize="24px">
+              {Object.keys(dexListConfig).length - 1}+{/* DMM and KyberSwap are one */}
+            </Text>
+            <Text color={theme.subText} marginTop="4px" fontSize="14px">
+              <Trans>DEXs</Trans>
+            </Text>
+          </ForTraderInfoCell>
+        </ForTraderInfoRow>
 
-          <ForTraderDivider horizontal={!above992} />
+        <ForTraderDivider horizontal={upToLarge} />
 
-          <Flex sx={{ gap: '24px' }} height={above992 ? '100%' : 'unset'} width={above992 ? 'unset' : '100%'}>
-            <Flex flexDirection="column" alignItems="center" flex={!above992 ? 1 : 'unset'}>
-              <Text fontWeight="600" fontSize="24px">
-                {MAINNET_NETWORKS.length}
-              </Text>
-              <Text color={theme.subText} marginTop="4px" fontSize="14px">
-                <Trans>Chains</Trans>
-              </Text>
-            </Flex>
-            <ForTraderDivider />
-            <Flex flexDirection="column" alignItems="center" flex={!above992 ? 1 : 'unset'}>
-              <Text fontWeight="600" fontSize="24px">
-                20,000+
-              </Text>
-              <Text color={theme.subText} marginTop="4px" fontSize="14px">
-                <Trans>Tokens</Trans>
-              </Text>
-            </Flex>
-          </Flex>
-        </ForTraderInfo>
-      </div>
-    </>
+        <ForTraderInfoRow>
+          <ForTraderInfoCell>
+            <Text fontWeight="600" fontSize="24px">
+              {MAINNET_NETWORKS.length}
+            </Text>
+            <Text color={theme.subText} marginTop="4px" fontSize="14px">
+              <Trans>Chains</Trans>
+            </Text>
+          </ForTraderInfoCell>
+          <ForTraderDivider />
+          <ForTraderInfoCell>
+            <Text fontWeight="600" fontSize="24px">
+              20,000+
+            </Text>
+            <Text color={theme.subText} marginTop="4px" fontSize="14px">
+              <Trans>Tokens</Trans>
+            </Text>
+          </ForTraderInfoCell>
+        </ForTraderInfoRow>
+      </ForTraderInfo>
+    </Box>
   )
 }
 

--- a/src/pages/About/styleds.tsx
+++ b/src/pages/About/styleds.tsx
@@ -111,17 +111,16 @@ export const ForTraderInfo = styled(Flex)`
   margin-top: 20px;
   background-color: ${({ theme }) => theme.background2};
   padding: 20px 0;
-  display: flex;
-  gap: 24px;
   border-radius: 8px;
   justify-content: center;
   align-items: center;
   border: 1px solid ${({ theme }) => theme.primary};
   position: relative;
 
-  ${({ theme }) => theme.mediaWidth.upToMedium`
+  ${({ theme }) => theme.mediaWidth.upToLarge`
     flex-direction: column;
     padding: 20px 16px;
+    gap: 24px;
   `}
 `
 
@@ -134,7 +133,7 @@ export const ForTraderInfoShadow = styled.div`
   bottom: -1px;
   left: 0;
 
-  ${({ theme }) => theme.mediaWidth.upToMedium`
+  ${({ theme }) => theme.mediaWidth.upToLarge`
     top: 0;
     bottom: -12px;
     left: -1px;

--- a/src/pages/Campaign/LeaderboardLayout.tsx
+++ b/src/pages/Campaign/LeaderboardLayout.tsx
@@ -1,20 +1,21 @@
 import React from 'react'
-import { Text } from 'rebass'
+import { Text, Flex } from 'rebass'
 import { Clock } from 'react-feather'
-import Search from 'components/Search'
+import { useSelector } from 'react-redux'
 import { t, Trans } from '@lingui/macro'
+import styled, { css } from 'styled-components'
+import { useMedia, useSize } from 'react-use'
+import { rgba } from 'polished'
+
+import Search, { Wrapper as SearchWrapper, Container as SearchContainer } from 'components/Search'
 import getShortenAddress from 'utils/getShortenAddress'
 import { formatNumberWithPrecisionRange } from 'utils'
-import styled, { css } from 'styled-components'
-import { rgba } from 'polished'
 import useTheme from 'hooks/useTheme'
-import { useMedia, useSize } from 'react-use'
 import Gold from 'assets/svg/gold_icon.svg'
 import Silver from 'assets/svg/silver_icon.svg'
 import Bronze from 'assets/svg/bronze_icon.svg'
 import Pagination from 'components/Pagination'
 import { CAMPAIGN_LEADERBOARD_ITEM_PER_PAGE, DEFAULT_SIGNIFICANT } from 'constants/index'
-import { useSelector } from 'react-redux'
 import { AppState } from 'state'
 import {
   useSelectedCampaignLeaderboardLookupAddressManager,
@@ -143,7 +144,7 @@ export default function LeaderboardLayout({
   return (
     <LeaderboardContainer>
       <RefreshTextAndSearchContainer>
-        {selectedCampaign.campaignState === CampaignState.CampaignStateReady && type === 'leaderboard' ? (
+        {selectedCampaign.campaignState === CampaignState.CampaignStateReady && type === 'leaderboard' && (
           <RefreshTextContainer>
             <RefreshText>
               <Trans>Leaderboard refresh in</Trans>
@@ -156,15 +157,16 @@ export default function LeaderboardLayout({
               </Text>
             </CountdownContainer>
           </RefreshTextContainer>
-        ) : (
-          <div />
         )}
-        <Search
-          placeholder={t`Search by full address`}
-          searchValue={searchValue}
-          onSearch={setSearchValue}
-          style={{ background: theme.buttonBlack }}
-        />
+
+        <CustomSearchContainer>
+          <Search
+            placeholder={t`Search by full address`}
+            searchValue={searchValue}
+            onSearch={setSearchValue}
+            style={{ background: theme.buttonBlack }}
+          />
+        </CustomSearchContainer>
       </RefreshTextAndSearchContainer>
       <LeaderboardTable>
         <LeaderboardTableHeader noColumns={type === 'lucky_winner' ? 2 : isRewardShown ? 4 : 3}>
@@ -196,26 +198,55 @@ export default function LeaderboardLayout({
   )
 }
 
+const CustomSearchContainer = styled.div`
+  flex: 1 1 100%;
+
+  display: flex;
+  justify-content: flex-end;
+
+  ${SearchContainer} {
+    flex: 0 1 360px;
+  }
+
+  ${SearchWrapper} {
+    min-width: unset;
+  }
+
+  ${({ theme }) => theme.mediaWidth.upToMedium`
+    width: 100%;
+    flex: 0 0;
+
+    ${SearchContainer} {
+      flex: 1 1 100%;
+    }
+  `}
+`
+
 const LeaderboardContainer = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 16px;
+  padding: 16px 0;
 `
 
 const RefreshTextAndSearchContainer = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 16px;
+  align-content: center;
+
+  padding: 0 16px;
 
   ${({ theme }) => theme.mediaWidth.upToMedium`
-  ${css`
     flex-direction: column;
     gap: 16px;
-  `}
   `}
 `
 
 const RefreshTextContainer = styled.div`
+  flex-wrap: nowrap;
+  white-space: nowrap;
   display: flex;
   align-items: center;
   gap: 8px;
@@ -224,17 +255,19 @@ const RefreshTextContainer = styled.div`
 const RefreshText = styled.div`
   font-size: 12px;
   line-height: 14px;
-  color: ${({ theme }) => theme.border};
+  color: ${({ theme }) => theme.subText};
 `
 
 const CountdownContainer = styled.div`
+  width: 73px;
+  flex-wrap: nowrap;
   display: flex;
   align-items: center;
   gap: 6px;
   padding: 3px 6px;
   border-radius: 12px;
-  background: ${({ theme }) => rgba(theme.border, 0.1)};
-  color: ${({ theme }) => theme.border};
+  background: ${({ theme }) => rgba(theme.subText, 0.1)};
+  color: ${({ theme }) => theme.subText};
 `
 
 const LeaderboardTable = styled.div``
@@ -244,8 +277,6 @@ const LeaderboardTableHeader = styled.div<{ noColumns: 2 | 3 | 4 }>`
   display: grid;
   align-items: center;
   background: ${({ theme }) => theme.tableHeader};
-  border-top-left-radius: 20px;
-  border-top-right-radius: 20px;
 
   ${({ noColumns }) =>
     noColumns === 4
@@ -276,10 +307,7 @@ const LeaderboardTableHeader = styled.div<{ noColumns: 2 | 3 | 4 }>`
     }
     }`}
 
-  ${({ theme }) =>
-    theme.mediaWidth.upToSmall`${css`
-      padding: 16px;
-    `}`}
+  ${({ theme }) => theme.mediaWidth.upToSmall`padding: 16px;`}
 `
 
 const LeaderboardTableHeaderItem = styled.div<{ align?: 'left' | 'right' | 'center' }>`
@@ -314,11 +342,11 @@ const LeaderboardTableBodyItem = styled.div<{ align?: 'left' | 'right' | 'center
   white-space: nowrap;
 
   ${({ theme }) =>
-    theme.mediaWidth.upToMedium`${css`
+    theme.mediaWidth.upToMedium`
       font-size: 12px;
       line-height: 14px;
       font-weight: 400;
-    `}`}
+    `}
 `
 
 const MedalImg = styled.img`

--- a/src/pages/Campaign/index.tsx
+++ b/src/pages/Campaign/index.tsx
@@ -100,7 +100,12 @@ export default function Campaign() {
   const TabHowToWinContent = useMemo(
     // eslint-disable-next-line react/display-name
     () => () => (
-      <Flex flexDirection="column">
+      <Flex
+        flexDirection="column"
+        sx={{
+          padding: '24px',
+        }}
+      >
         <Flex
           justifyContent="space-between"
           alignItems="center"
@@ -184,7 +189,7 @@ export default function Campaign() {
   const TabRewardsContent = useMemo(
     // eslint-disable-next-line react/display-name
     () => () => (
-      <Flex flexDirection="column" style={{ gap: '20px' }}>
+      <Flex flexDirection="column" sx={{ gap: '20px', padding: '24px' }}>
         <Text fontSize={16} fontWeight={500}>
           <Trans>Rewards</Trans>
         </Text>
@@ -485,7 +490,6 @@ export default function Campaign() {
 }
 
 const CampaignDetailContent = styled.div`
-  padding: 28px 24px;
   background: ${({ theme }) => theme.background};
   border-radius: 20px;
   flex: 1;

--- a/src/pages/Pools/InstructionAndGlobalData.tsx
+++ b/src/pages/Pools/InstructionAndGlobalData.tsx
@@ -1,14 +1,16 @@
 import React, { useState } from 'react'
 import styled from 'styled-components'
 import { Trans } from '@lingui/macro'
+import { Text, Flex } from 'rebass'
+import { ChevronDown } from 'react-feather'
+import { isMobile } from 'react-device-detect'
+
 import { ExternalLink } from 'theme'
 import { formatBigLiquidity } from 'utils/formatBalance'
 import Loader from 'components/Loader'
 import { useGlobalData } from 'state/about/hooks'
 import useParsedQueryString from 'hooks/useParsedQueryString'
 import { VERSION } from 'constants/v2'
-import { Text, Flex } from 'rebass'
-import { ChevronDown } from 'react-feather'
 import { LowestSlippage, BestPrice, MoneyBag } from 'components/Icons'
 import AntiSnippingAttack from 'components/Icons/AntiSnippingAttack'
 import useTheme from 'hooks/useTheme'
@@ -105,7 +107,7 @@ export const Instruction = () => {
 
   const theme = useTheme()
 
-  const [show, setShow] = useState(true)
+  const [show, setShow] = useState(!isMobile) // hide by default on mobile
 
   return (
     <InstructionItem>


### PR DESCRIPTION
# Description
There are some minor UI issues left from the last feature. This PR addresses:
- Page Earn/Farm: collapse instruction by default on mobile
![image](https://user-images.githubusercontent.com/19758667/181211869-c1ae348e-39f5-4e8a-994d-9ccbcbc08b1c.png)


- Page Campaign: remove some redundant padding on mobile
![image](https://user-images.githubusercontent.com/19758667/181211824-9eef38da-1a19-4a9d-b8f1-9fe85084f0dd.png)


- Page About: make the for-trader info sections align center
![image](https://user-images.githubusercontent.com/19758667/181211762-86d1148a-6393-40f7-b092-415bf341a668.png)
