### PR TITLE
Stop fetching data on focus to avoid loading indicator in Campaign page

### DIFF
--- a/src/state/campaigns/updater.tsx
+++ b/src/state/campaigns/updater.tsx
@@ -42,105 +42,111 @@ export default function CampaignsUpdater(): null {
 
   const { data: campaignData, isValidating: isLoadingCampaignData, error: loadingCampaignDataError } = useSWR<
     CampaignData[]
-  >(isCampaignPage ? SWR_KEYS.getListCampaign : null, async (url: string) => {
-    const response = await axios({
-      method: 'GET',
-      url,
-      params: {
-        limit: MAXIMUM_ITEMS_PER_REQUEST,
-        offset: 0,
-      },
-    })
-    const now = Date.now()
-    const campaigns: [] = response.data.data
-      .map((item: any) => ({ ...item, startTime: item.startTime * 1000, endTime: item.endTime * 1000 }))
-      .sort((a: any, b: any) => {
-        const a_status = a.endTime <= now ? 'Ended' : a.startTime >= now ? 'Upcoming' : 'Ongoing'
-        const b_status = b.endTime <= now ? 'Ended' : b.startTime >= now ? 'Upcoming' : 'Ongoing'
-        const STATUS_PRIORITY = ['Ongoing', 'Upcoming', 'Ended']
-        const a_status_index = STATUS_PRIORITY.indexOf(a_status)
-        const b_status_index = STATUS_PRIORITY.indexOf(b_status)
-        if (a_status_index !== b_status_index) return a_status_index - b_status_index
-        if (a.startTime !== b.startTime) return b.startTime - a.startTime
-        return b.endTime - a.endTime
+  >(
+    isCampaignPage ? SWR_KEYS.getListCampaign : null,
+    async (url: string) => {
+      const response = await axios({
+        method: 'GET',
+        url,
+        params: {
+          limit: MAXIMUM_ITEMS_PER_REQUEST,
+          offset: 0,
+        },
       })
-    const formattedCampaigns: CampaignData[] = campaigns.map((campaign: any) => {
-      const rewardDistribution: RewardDistribution[] = []
-      if (campaign.rewardDistribution.single) {
-        campaign.rewardDistribution.single.forEach(
-          ({ amount, rank, token }: { amount: string; rank: number; token: SerializedToken }) => {
-            rewardDistribution.push({
-              type: 'Single',
-              amount,
-              rank,
-              token,
-            })
-          },
-        )
-      }
-      if (campaign.rewardDistribution.range) {
-        campaign.rewardDistribution.range.forEach(
-          ({ from, to, amount, token }: { from: number; to: number; amount: string; token: SerializedToken }) => {
-            rewardDistribution.push({
-              type: 'Range',
+      const now = Date.now()
+      const campaigns: [] = response.data.data
+        .map((item: any) => ({ ...item, startTime: item.startTime * 1000, endTime: item.endTime * 1000 }))
+        .sort((a: any, b: any) => {
+          const a_status = a.endTime <= now ? 'Ended' : a.startTime >= now ? 'Upcoming' : 'Ongoing'
+          const b_status = b.endTime <= now ? 'Ended' : b.startTime >= now ? 'Upcoming' : 'Ongoing'
+          const STATUS_PRIORITY = ['Ongoing', 'Upcoming', 'Ended']
+          const a_status_index = STATUS_PRIORITY.indexOf(a_status)
+          const b_status_index = STATUS_PRIORITY.indexOf(b_status)
+          if (a_status_index !== b_status_index) return a_status_index - b_status_index
+          if (a.startTime !== b.startTime) return b.startTime - a.startTime
+          return b.endTime - a.endTime
+        })
+      const formattedCampaigns: CampaignData[] = campaigns.map((campaign: any) => {
+        const rewardDistribution: RewardDistribution[] = []
+        if (campaign.rewardDistribution.single) {
+          campaign.rewardDistribution.single.forEach(
+            ({ amount, rank, token }: { amount: string; rank: number; token: SerializedToken }) => {
+              rewardDistribution.push({
+                type: 'Single',
+                amount,
+                rank,
+                token,
+              })
+            },
+          )
+        }
+        if (campaign.rewardDistribution.range) {
+          campaign.rewardDistribution.range.forEach(
+            ({ from, to, amount, token }: { from: number; to: number; amount: string; token: SerializedToken }) => {
+              rewardDistribution.push({
+                type: 'Range',
+                from,
+                to,
+                amount,
+                token,
+              })
+            },
+          )
+        }
+        if (campaign.rewardDistribution.random) {
+          campaign.rewardDistribution.random.forEach(
+            ({
               from,
               to,
               amount,
+              numberOfWinners,
               token,
-            })
-          },
-        )
-      }
-      if (campaign.rewardDistribution.random) {
-        campaign.rewardDistribution.random.forEach(
-          ({
-            from,
-            to,
-            amount,
-            numberOfWinners,
-            token,
-          }: {
-            from: number
-            to: number
-            amount: string
-            numberOfWinners: number
-            token: SerializedToken
-          }) => {
-            rewardDistribution.push({
-              type: 'Random',
-              from,
-              to,
-              amount,
-              nWinners: numberOfWinners,
-              token,
-            })
-          },
-        )
-      }
-      const { startTime, endTime } = campaign
-      return {
-        id: campaign.id,
-        name: campaign.name,
-        startTime,
-        endTime,
-        desktopBanner: campaign.desktopBanner,
-        mobileBanner: campaign.mobileBanner,
-        status: endTime <= now ? 'Ended' : startTime >= now ? 'Upcoming' : 'Ongoing',
-        rules: campaign.rules,
-        termsAndConditions: campaign.termsAndConditions,
-        otherDetails: campaign.otherDetails,
-        rewardDetails: campaign.rewardDetails,
-        isRewardShown: campaign.isRewardShown,
-        enterNowUrl: campaign.enterNowUrl,
-        rewardDistribution,
-        campaignState: campaign.campaignState,
-        chainIds: campaign.chainIds,
-        rewardChainIds: campaign.rewardChainIds,
-        tradingVolumeRequired: campaign.tradingVolumeRequired,
-      }
-    })
-    return formattedCampaigns
-  })
+            }: {
+              from: number
+              to: number
+              amount: string
+              numberOfWinners: number
+              token: SerializedToken
+            }) => {
+              rewardDistribution.push({
+                type: 'Random',
+                from,
+                to,
+                amount,
+                nWinners: numberOfWinners,
+                token,
+              })
+            },
+          )
+        }
+        const { startTime, endTime } = campaign
+        return {
+          id: campaign.id,
+          name: campaign.name,
+          startTime,
+          endTime,
+          desktopBanner: campaign.desktopBanner,
+          mobileBanner: campaign.mobileBanner,
+          status: endTime <= now ? 'Ended' : startTime >= now ? 'Upcoming' : 'Ongoing',
+          rules: campaign.rules,
+          termsAndConditions: campaign.termsAndConditions,
+          otherDetails: campaign.otherDetails,
+          rewardDetails: campaign.rewardDetails,
+          isRewardShown: campaign.isRewardShown,
+          enterNowUrl: campaign.enterNowUrl,
+          rewardDistribution,
+          campaignState: campaign.campaignState,
+          chainIds: campaign.chainIds,
+          rewardChainIds: campaign.rewardChainIds,
+          tradingVolumeRequired: campaign.tradingVolumeRequired,
+        }
+      })
+      return formattedCampaigns
+    },
+    {
+      revalidateOnFocus: false,
+    },
+  )
 
   const { selectedCampaignId } = useParsedQueryString()
   const history = useHistory()


### PR DESCRIPTION
# Description
Losing focus and then gaining focus again in Campaign page will trigger useSWR to fetch data again. We don't want and like this behavior. I just turn it off.